### PR TITLE
Update unidad_2_chatear.md

### DIFF
--- a/unidad_2_chatear.md
+++ b/unidad_2_chatear.md
@@ -1,1 +1,3 @@
 {% include "git+https://github.com/catedu/cdteams.git/unidad_2_chatear.md" %} 
+
+Una vez que nos hemos dado de alta, podemos CREAR nuestro canal e invitar a la participación mediante URL.


### PR DESCRIPTION
(En el Punto 2.3. Discord: Chat de voz) Falta añadir la palabra "crear" en una de las frases. "Una vez que nos hemos dado de alta, podemos CREAR nuestro canal e invitar a la participación mediante URL."